### PR TITLE
camera screen 아이콘 수정 / 색 추천 페이지 오류 수정

### DIFF
--- a/lib/screens/camera_screen.dart
+++ b/lib/screens/camera_screen.dart
@@ -156,8 +156,13 @@ class _CameraScreenState extends State<CameraScreen> {
                           icon: Icons.colorize,
                           onColor: (value) => {},
                           onColorChanged: (value) {
-                            hoveredColor.value = abgr2Color(
-                                int.parse(cutColor(value), radix: 16));
+                            if (Platform.isIOS) {
+                              hoveredColor.value = abgr2Color(
+                                  int.parse(cutColor(value), radix: 16));
+                            } else {
+                              hoveredColor.value =
+                                  Color(int.parse(cutColor(value), radix: 16));
+                            }
                             setState(() {
                               colorHex = hoveredColor.value
                                   .toString()
@@ -177,7 +182,7 @@ class _CameraScreenState extends State<CameraScreen> {
                               isClicked = !isClicked;
                             });
                           },
-                          icon: const Icon(Icons.mode_comment),
+                          icon: const Icon(Icons.change_circle),
                         ),
                       ),
                     ),

--- a/lib/screens/color_suggest_screen.dart
+++ b/lib/screens/color_suggest_screen.dart
@@ -56,10 +56,14 @@ class _ColorSuggestScreenState extends State<ColorSuggestScreen> {
     ['fashion', '00000', 'asdasda'],
   ];
 
-  List<Text> buttons = [Text('PPT'), Text('fashion'), Text('interior')];
+  List<Text> buttons = [
+    const Text('PPT'),
+    const Text('fashion'),
+    const Text('interior')
+  ];
 
   List<bool> button_selected = [false, false, false];
-  int color_num = -1;
+  late int color_num;
 
   @override
   void initState() {
@@ -67,6 +71,9 @@ class _ColorSuggestScreenState extends State<ColorSuggestScreen> {
     if (widget.color != "") {
       colorPack[0] = widget.color.toColor();
       colorFlag[0] = true;
+      color_num = 0;
+    } else {
+      color_num = -1;
     }
   }
 
@@ -130,7 +137,7 @@ class _ColorSuggestScreenState extends State<ColorSuggestScreen> {
                       color_num++;
                     }
                   },
-                  child: Icon(
+                  child: const Icon(
                     Icons.add,
                     size: 50,
                   ),
@@ -168,8 +175,8 @@ class _ColorSuggestScreenState extends State<ColorSuggestScreen> {
                               }
                             });
                           },
-                          children: buttons,
                           isSelected: button_selected,
+                          children: buttons,
                         );
                       },
                     )


### PR DESCRIPTION
camera screen 아이콘 수정
색 추천 페이지 오류 수정
- camera screen에서 색 추천 페이지로 넘어간 뒤, 색 추가 시 camera screen에서 불러온 색 위에 덮어씌워지는 오류 수정.